### PR TITLE
Enable m1-terraform-provider-helper to bulid project.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+default: build
+
+build:
+	go install


### PR DESCRIPTION
As there is no ARM binary release this change is a quick fix that would allow users to make use of the [m1-terraform-provider-helper](https://github.com/kreuzwerker/m1-terraform-provider-helper) tool without specifying any additional flags.
